### PR TITLE
Added py.typed file to comply with PEP 561 for distributing type information and allowing to run type checkers from different environments

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -124,4 +124,7 @@ setup(
     python_requires='>=3.6',
     packages=find_packages(),
     ext_modules=[lib_choco],
+    package_data={
+        'pychoco': ['py.typed'],
+    },
 )


### PR DESCRIPTION
See [PEP 561](https://peps.python.org/pep-0561/).

Allows type checkers such as `mypy`, `pyright`, etc. to run and correctly parse code which uses `pychoco` when `pychoco` is installed in a different environment than the type checkers.