### PR TITLE
Use caches for pip, maven and choco-solver-capi in GitHub Actions and cleaning a bit the GitHub workflow files

### DIFF
--- a/.github/actions/build-choco-solver-capi/action.yml
+++ b/.github/actions/build-choco-solver-capi/action.yml
@@ -1,0 +1,54 @@
+name: "Build choco-solver-capi"
+
+description: "build choco-solver-capi and caches it"
+
+inputs:
+  os:
+    description: target OS
+    required: true
+    type: string
+  arch:
+    description: target arch
+    required: true
+    type: string
+  cache:
+    description: if true, caches the result
+    required: false
+    default: true
+    type: string
+
+runs:
+  using: composite
+  steps:
+    - name: Check out repository
+      uses: actions/checkout@v4
+      with:
+        submodules: recursive
+    - name: Check choco-solver-capi latest commit
+      shell: bash
+      run: echo "CHOCO_CAPI_LATEST_HASH=$(git -C choco-solver-capi log HEAD -n 1 --pretty=format:%h)" >> "$GITHUB_ENV"
+    - if: ${{ inputs.cache == 'true' }}
+      name: Cache choco-solver-capi build
+      id: cache-choco-solver-capi
+      uses: actions/cache@v4
+      env:
+        cache-name: cache-choco-solver-capi-build
+      with:
+        path: choco-solver-capi
+        key: ${{ inputs.os }}-${{ inputs.arch }}-build-${{ env.cache-name }}-${{ env.CHOCO_CAPI_LATEST_HASH }}
+    - if: ${{ (inputs.cache != 'true') || (steps.cache-choco-solver-capi.outputs.cache-hit != 'true') }}
+      name: Set up Visual Studio shell (only for Windows)
+      uses: ilammy/msvc-dev-cmd@v1
+      with:
+        arch: x64
+    - if: ${{ (inputs.cache != 'true') || (steps.cache-choco-solver-capi.outputs.cache-hit != 'true') }}
+      name: Set up GraalVM Native Image toolchain
+      uses: graalvm/setup-graalvm@v1
+      with:
+        java-version: '22'
+        distribution: 'graalvm'
+        cache: 'maven'
+    - if: ${{ (inputs.cache != 'true') || (steps.cache-choco-solver-capi.outputs.cache-hit != 'true') }}
+      name: Build choco-solver-capi
+      shell: bash
+      run: (cd choco-solver-capi ; sh build.sh)

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -8,81 +8,64 @@ on:
 jobs:
   build-macos:
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 30
+    timeout-minutes: 20
     strategy:
-      fail-fast: false
       matrix:
-        os: [macos-14, macos-13, macos-12]
-        python-version: ["3.11"]
-        arch: [arm64, x86_64]
         include:
-          - os: macos-14
-            arch: arm64
-            CIBW_ENVIRONMENT: MACOSX_DEPLOYMENT_TARGET=14.0
-            force: true
-          - os: macos-13
-            arch: arm64
-            CIBW_ENVIRONMENT: MACOSX_DEPLOYMENT_TARGET=13.0
-            force: true
-          - os: macos-12
-            arch: arm64
-            CIBW_ENVIRONMENT: MACOSX_DEPLOYMENT_TARGET=12.0
-            force: true
-          - os: macos-14
+          - os: "macos-13"
             arch: x86_64
-            CIBW_ENVIRONMENT: MACOSX_DEPLOYMENT_TARGET=14.0
-            force: true
-          - os: macos-13
-            arch: x86_64
-            CIBW_ENVIRONMENT: MACOSX_DEPLOYMENT_TARGET=13.0
-            force: true
-          - os: macos-12
-            arch: x86_64
-            CIBW_ENVIRONMENT: MACOSX_DEPLOYMENT_TARGET=12.0
-            force: true
+            python-version: "3.11"
+            CIBW_ENVIRONMENT: MACOSX_DEPLOYMENT_TARGET=11.0
+          - os: "macos-14"
+            arch: arm64
+            python-version: "3.11"
+            CIBW_ENVIRONMENT: MACOSX_DEPLOYMENT_TARGET=11.0
+          - os: "macos-15"
+            arch: arm64
+            python-version: "3.11"
+            CIBW_ENVIRONMENT: MACOSX_DEPLOYMENT_TARGET=11.0
     steps:
-      # if matrix.force is not true or event is not tag, skip
-      - if: ${{ matrix.force }} != true || (github.event_name == 'push' && !startsWith(github.ref, 'refs/tags'))
-        run: 
-          echo "Skipping job for ${{ matrix.os }} ${{ matrix.python-version }}"
-          exit 0
+      - name: Print system info
+        run: echo $(uname -o) $(uname -r) $(uname -m)
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
       - name: Setup python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           architecture: x64
+          cache: 'pip'
+          cache-dependency-path: '**/requirements*.txt'
       - name: Install setuptools (needed from Python 3.12)
         run: pip install setuptools
-      - name: Set up GraalVM Native Image toolchain
-        uses: graalvm/setup-graalvm@v1
-        with:
-          java-version: '22'
-          distribution: 'graalvm'
       - name: Install Swig
         run: brew install swig
-      - name: Update repository
+      - name: Build choco-solver-capi
+        uses: ./.github/actions/build-choco-solver-capi
+        with:
+          os: ${{ runner.os }}
+          arch: ${{ matrix.arch }}
+      - name: Build pychoco
         run: |
-          git submodule update --init --recursive
-      - name: Build
-        run: |
-          sh build.sh nowheel
+          sh build.sh nocapibuild nowheel
           pip install pychoco -f dist/
-      - name: Build wheels
+      - name: Test
+        run: |
+          pip install pytest
+          pip install -r requirements_tests.txt
+          pytest
+      - if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+        name: Build wheels
         uses: pypa/cibuildwheel@v2.21.1
         env:
           CIBW_ARCHS: ${{ matrix.arch }}
           CIBW_ENVIRONMENT: ${{ matrix.CIBW_ENVIRONMENT }}
         with:
           output-dir: dist
-      - name: Test
-        run: |
-          pip install pytest
-          pip install -r requirements_tests.txt
-          pytest
-      - name: Upload wheel artifacts
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+      - if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+        name: Upload wheel artifacts
         uses: actions/upload-artifact@v4
         with:
           name: wheel-${{matrix.os}}-${{matrix.python-version}}-${{matrix.arch}}-artifact
@@ -91,32 +74,20 @@ jobs:
 
   upload-pypi-macos:
     needs: build-macos
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
     strategy:
       matrix:
-        os : [macos-14, macos-13, macos-12]
-        arch: [arm64, x86_64]
-        python-version: [ "3.11" ]
         include:
-          - os: macos-14
-            arch: arm64
-            force: true
-          - os: macos-13
-            arch: arm64
-            force: true
-          - os: macos-12
-            arch: arm64
-            force: true
-          - os: macos-14
+          - os: "macos-13"
             arch: x86_64
-            force: true
-          - os: macos-13
-            arch: x86_64
-            force: true
-          - os: macos-12
-            arch: x86_64
-            force: true
+            python-version: "3.11"
+          - os: "macos-14"
+            arch: arm64
+            python-version: "3.11"
+          - os: "macos-15"
+            arch: arm64
+            python-version: "3.11"
     steps:
     - name: Download artifacts
       uses: actions/download-artifact@v4
@@ -126,7 +97,6 @@ jobs:
     - name: List files
       run: ls -R
     - name: Upload to PyPi
-      if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
         user: __token__

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -8,54 +8,38 @@ on:
 jobs:
   build-ubuntu:
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 30
+    timeout-minutes: 20
     strategy:
-      fail-fast: true
       matrix:
-        os : [ubuntu-20.04]
+        os : [ubuntu-22.04]
         arch: [x86_64]
         python-version: ["3.11"]
         #python-version: ["3.12", "3.11", "3.10", "3.9"]
     steps:
-      # if matrix.force is not true or event is not tag, skip
-      - if: ${{ matrix.force }} != true || (github.event_name == 'push' && !startsWith(github.ref, 'refs/tags'))
-        run: 
-          echo "Skipping job for ${{ matrix.os }} ${{ matrix.python-version }}"
-          exit 0
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
       - name: Setup python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           architecture: x64
-      - name: Display Python version
-        run: |
-          python -c "import sys; print(sys.version)"
+          cache: 'pip'
+          cache-dependency-path: '**/requirements*.txt'
       - name: Install setuptools (needed from Python 3.12)
         run: pip install setuptools
-      - name: Set up GraalVM Native Image toolchain
-        uses: graalvm/setup-graalvm@v1
-        with:
-          java-version: '22'
-          distribution: 'graalvm'
       - name: Install Swig
         run: sudo apt-get install swig
-      - name: Update repository
-        run: |
-          git submodule update --init --recursive
-      - name: Build
-        run: |
-          sh build.sh nowheel
-          pip install pychoco -f dist/
-      - name: Build wheels
-        uses: pypa/cibuildwheel@v2.21.1
-        env:
-          CIBW_SKIP: "*-musllinux*"
-          CIBW_BUILD_FRONTEND: build
-          CIBW_ARCHS: ${{ matrix.arch }}
+      - name: Build choco-solver-capi
+        uses: ./.github/actions/build-choco-solver-capi
         with:
-          output-dir: dist
+          os: ${{ runner.os }}
+          arch: ${{ matrix.arch }}
+      - name: Build pychoco
+        run: |
+          sh build.sh nocapibuild nowheel
+          pip install pychoco -f dist/
       - name: Test
         run: |
           pip install pytest
@@ -67,8 +51,17 @@ jobs:
           coverage run -m unittest
       - name: Upload Coverage to Codecov
         uses: codecov/codecov-action@v3
-      - name: Upload to PyPi
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+      - if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+        name: Build wheels
+        uses: pypa/cibuildwheel@v2.21.1
+        env:
+          CIBW_SKIP: "*-musllinux*"
+          CIBW_BUILD_FRONTEND: build
+          CIBW_ARCHS: ${{ matrix.arch }}
+        with:
+          output-dir: dist
+      - if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+        name: Upload to PyPi
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -8,58 +8,53 @@ on:
 jobs:
   build-windows:
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 30
+    timeout-minutes: 20
     strategy:
-      fail-fast: false
       matrix:
         os : [windows-2022]
+        arch: [x86_64]
         python-version: ["3.11"]
     steps:
-      # if matrix.force is not true or event is not tag, skip
-      - if: ${{ matrix.force }} != true || (github.event_name == 'push' && !startsWith(github.ref, 'refs/tags'))
-        run: 
-          echo "Skipping job for ${{ matrix.os }} ${{ matrix.python-version }}"
-          exit 0
+      - name: Print system info
+        run: echo $(uname -o) $(uname -r) $(uname -m)
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
       - name: Setup python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           architecture: x64
+          cache: 'pip'
+          cache-dependency-path: '**/requirements*.txt'
       - name: Install setuptools (needed from Python 3.12)
         run: pip install setuptools
-      - name: Set up GraalVM Native Image toolchain
-        uses: graalvm/setup-graalvm@v1
-        with:
-          java-version: '22'
-          distribution: 'graalvm'
       - name: Install Swig
         run: choco install swig
-      - name: Update repository
-        run: |
-          git submodule update --init --recursive
-      - name: Set up Visual Studio shell
-        uses: ilammy/msvc-dev-cmd@v1
+      - name: Build choco-solver-capi
+        uses: ./.github/actions/build-choco-solver-capi
         with:
-          arch: x64
-      - name: Build
+          os: ${{ runner.os }}
+          arch: ${{ matrix.arch }}
+      - name: Build pychoco
         run: |
-          sh build.sh nowheel
+          sh build.sh nocapibuild nowheel
           pip install pychoco -f dist/
-      - name: Build wheels
-        uses: pypa/cibuildwheel@v2.21.1
-        env:
-          CIBW_ARCHS: AMD64
-        with:
-          output-dir: dist
       - name: Test
         run: |
           pip install -U pytest
           pip install -r requirements_tests.txt
           pytest
-      - name: Upload wheel artifacts
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+      - if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+        name: Build wheels
+        uses: pypa/cibuildwheel@v2.21.1
+        env:
+          CIBW_ARCHS: AMD64
+        with:
+          output-dir: dist
+      - if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+        name: Upload wheel artifacts
         uses: actions/upload-artifact@v3
         with:
           name: wheel-${{matrix.os}}-${{matrix.python-version}}-artifact
@@ -69,7 +64,7 @@ jobs:
 
   upload-pypi-windows:
     needs: build-windows
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
     strategy:
       matrix:
@@ -84,7 +79,6 @@ jobs:
     - name: List files
       run: ls -R
     - name: Upload to PyPi
-      if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
         user: __token__

--- a/build.sh
+++ b/build.sh
@@ -1,11 +1,31 @@
-# NOTE: befaure launching ensure that $JAVA_HOME points
+# NOTE: before launching, ensure that $JAVA_HOME points
 # to graalVM
 
+# Parse command line arguments
+for i in "$@"; do
+  case $i in
+    nocapibuild)
+      NO_CAPI_BUILD=true
+      shift
+      ;;
+    nowheel)
+      NO_WHEEL=true
+      shift
+      ;;
+    *)
+      echo "Unknown option $i"
+      exit 1
+      ;;
+  esac
+done
+
 # Build choco-solver-capi
-cd choco-solver-capi
-git pull origin master
-sh ./build.sh
-cd ..
+if [ "$NO_CAPI_BUILD" != true ]; then
+  cd choco-solver-capi
+  git pull origin master
+  sh ./build.sh
+  cd ..
+fi
 
 # Clean previous build
 rm -f -r build
@@ -14,18 +34,18 @@ rm -f pychoco/backend_wrap.c
 rm -f pychoco/*.so
 
 # Create C interface to python with SWIG
-swig -python -py3 pychoco/backend.i
+swig -python pychoco/backend.i
 
 # Build extensions
-#pip3 install .
+#pip install .
 
-python3 setup.py develop -e -b .
-if [$1 != "nowheel"]; then
+python setup.py develop -e -b .
+if [ "$NO_WHEEL" != true ]; then
   pip install wheel
   OS=`uname`
   if [ "$OS" = "Linux" ]; then
-      python setup.py bdist_wheel --plat manylinux2014_x86_64
+    python setup.py bdist_wheel --plat manylinux2014_x86_64
   else
-      python3 setup.py bdist_wheel
+    python setup.py bdist_wheel
   fi
 fi


### PR DESCRIPTION
Speeds up workflows by caching choco-solver-capi build instead of rebuild it even when no modifications on the C API was made.
Also, don't always build wheels, only when needed, i.e., for each release.